### PR TITLE
Allow speed_unit to be passed to request

### DIFF
--- a/lib/google_maps_service/apis/roads.rb
+++ b/lib/google_maps_service/apis/roads.rb
@@ -63,8 +63,9 @@ module GoogleMapsService::Apis
     #         by the snap_to_roads function. You can pass up to 100 Place IDs.
     #
     # @return [Array] Array of speed limits.
-    def speed_limits(place_ids)
+    def speed_limits(place_ids, speed_unit='KPH')
       params = GoogleMapsService::Convert.as_list(place_ids).map { |place_id| ['placeId', place_id] }
+      params << ['units', speed_unit]
 
       return get('/v1/speedLimits', params,
                  base_url: ROADS_BASE_URL,

--- a/lib/google_maps_service/apis/roads.rb
+++ b/lib/google_maps_service/apis/roads.rb
@@ -65,7 +65,7 @@ module GoogleMapsService::Apis
     # @return [Array] Array of speed limits.
     def speed_limits(place_ids, speed_unit='KPH')
       params = GoogleMapsService::Convert.as_list(place_ids).map { |place_id| ['placeId', place_id] }
-      params << ['units', speed_unit]
+      params << ['units', speed_unit] if speed_unit == 'MPH'
 
       return get('/v1/speedLimits', params,
                  base_url: ROADS_BASE_URL,

--- a/lib/google_maps_service/apis/roads.rb
+++ b/lib/google_maps_service/apis/roads.rb
@@ -65,7 +65,7 @@ module GoogleMapsService::Apis
     # @return [Array] Array of speed limits.
     def speed_limits(place_ids, units: 'KPH')
       params = GoogleMapsService::Convert.as_list(place_ids).map { |place_id| ['placeId', place_id] }
-      params = params.to_h
+      params = Hash[params.map {|k,v| [k, v]}]
       params['units'] = units if units.match(/^mph$/i)
 
       return get('/v1/speedLimits', params,

--- a/lib/google_maps_service/apis/roads.rb
+++ b/lib/google_maps_service/apis/roads.rb
@@ -63,9 +63,10 @@ module GoogleMapsService::Apis
     #         by the snap_to_roads function. You can pass up to 100 Place IDs.
     #
     # @return [Array] Array of speed limits.
-    def speed_limits(place_ids, speed_unit='KPH')
+    def speed_limits(place_ids, units: 'KPH')
       params = GoogleMapsService::Convert.as_list(place_ids).map { |place_id| ['placeId', place_id] }
-      params << ['units', speed_unit]
+      params = params.to_h
+      params['units'] = units if units.match(/^mph$/i)
 
       return get('/v1/speedLimits', params,
                  base_url: ROADS_BASE_URL,
@@ -92,12 +93,13 @@ module GoogleMapsService::Apis
     #
     # @return [Hash] A hash with both a list of speed limits and a list of the snapped
     #         points.
-    def snapped_speed_limits(path)
+    def snapped_speed_limits(path, units: 'KPH')
       path = GoogleMapsService::Convert.waypoints(path)
 
       params = {
-        path: path
-      }
+        path: path,
+        units: (units if units.match(/^mph$/i))
+      }.reject {|k,v| v.nil?}
 
       return get('/v1/speedLimits', params,
                  base_url: ROADS_BASE_URL,

--- a/lib/google_maps_service/apis/roads.rb
+++ b/lib/google_maps_service/apis/roads.rb
@@ -65,7 +65,7 @@ module GoogleMapsService::Apis
     # @return [Array] Array of speed limits.
     def speed_limits(place_ids, units: 'KPH')
       params = GoogleMapsService::Convert.as_list(place_ids).map { |place_id| ['placeId', place_id] }
-      params = Hash[params.map {|k,v| [k, v]}]
+      params = Hash[params]
       params['units'] = units if units.match(/^mph$/i)
 
       return get('/v1/speedLimits', params,


### PR DESCRIPTION
#### Explanation:
This change leaves KPH as the default while adding the ability to send 'MPH' to the roads.rb

#### Example request:

```
google_client = GoogleMapsService::Client.new
google_client.speed_limits('ChIJaw1TDuC22YgRf6hEN94cT58')
=> [{:placeId=>"ChIJaw1TDuC22YgRf6hEN94cT58", :speedLimit=>88.51392, :units=>"KPH"}]

google_client = GoogleMapsService::Client.new
google_client.speed_limits('ChIJaw1TDuC22YgRf6hEN94cT58', units: 'MPH')
=> [{:placeId=>"ChIJaw1TDuC22YgRf6hEN94cT58", :speedLimit=>55, :units=>"MPH"}]
```